### PR TITLE
pull token from environment variable instead of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,23 @@ Source providers such as `koop-github` require that you first install koop:
 ```bash
 git clone git@github.com:Esri/koop.git
 cd koop
-npm install 
-# copy and edit the config file
-cp config/default.yml.example config/default.yml
+npm install
 ```
 
-you can then install `koop-github`. 
+you can then install `koop-github`.
 
 ```bash
 npm install https://github.com/chelm/koop-github/tarball/master
 
 # start the koop server
-node server.js 
+node server.js
+```
+
+in order to avoid hitting cap on amount of anonymous requests that can be made to Github, create a [token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) and supply it as an environment variable when launching koop
+
+```bash
+# start the koop server
+KOOP_GITHUB_TOKEN=xxx node server.js
 ```
 
 ## Usage

--- a/models/config.js.example
+++ b/models/config.js.example
@@ -1,2 +1,0 @@
-// add your API Key and cp this file to config.js 
-exports.token = "XXXXXXXXXXXXXXXXXXXXXXX";


### PR DESCRIPTION
upgraded provider to read token from an environment variable instead of config file.
provide relevant warning if none has been specified
removed example config file
updated readme to include explanation of new pattern

`GITHUBTOKEN=xxx node server.js`

cc @ngoldman
