### PR TITLE
Updated model to account for repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ koop.server.listen(1338, function () {
 Once `koop-github` is registered as provider and you've started your Koop server, you can request GeoJSON files in Github repositories using this pattern.  Note that the path within the repo uses `::` as a directory separator:
 
 ```
-/github/{organization name}::{repository name}::{folder::path::to::geojson}/FeatureServer/0/query
+/github/{organization name}::{repository name}::{branch}::{folder::path::to::geojson}/FeatureServer/0/query
 ```
 
 so for example:
 
 ```
-http://localhost:1338/github/koopjs::geodata::countries::mexico/FeatureServer/0/query
+http://localhost:1338/github/koopjs::geodata::master::countries::mexico/FeatureServer/0/query
 ```
 
 ## Test

--- a/model/index.js
+++ b/model/index.js
@@ -16,7 +16,8 @@ Model.prototype.getData = function (req, callback) {
   const githubPath = req.params.id.split('::')
   const user = githubPath[0]
   const repo = githubPath[1]
-  const path = githubPath.slice(2).join('/')
+  const branch = githubPath[2] // Updated branch parameter for main vs master
+  const path = githubPath.slice(3).join('/')
 
   if (!repo || !path) callback(new Error('The "id" parameter must be of form "user::repo::path::to::file"'))
 
@@ -24,6 +25,7 @@ Model.prototype.getData = function (req, callback) {
   geohub.repo({
     user,
     repo,
+    branch,
     path,
     token: ghtoken
   }, (err, data) => {
@@ -35,7 +37,7 @@ Model.prototype.getData = function (req, callback) {
     // Add metadata
     geojson.metadata = geojson.metadata || {}
     geojson.metadata.title = geojson.metadata.name = githubPath[githubPath.length - 1]
-    geojson.metadata.description = `GeoJSON from https://raw.github.com/${user}/${repo}/master/${path}.geojson`
+    geojson.metadata.description = `GeoJSON from https://raw.github.com/${user}/${repo}/${branch}/${path}.geojson`
     geojson.metadata.geometryType = _.get(geojson, 'features[0].geometry.type')
     callback(null, geojson)
   })


### PR DESCRIPTION
Since github has changed the default branch to 'main' instead of 'master' the url parameters need to account for the 2 different default branch names that are are on the platform.

steps taken
- updated model/index.js to replace the 2 URL parameter with branch
- replaced "master" with branch parameter
- updated URL and URL parameter example in README.md